### PR TITLE
Get rid the excess close parentheses one.

### DIFF
--- a/company-graphql-pkg.el
+++ b/company-graphql-pkg.el
@@ -10,6 +10,4 @@
     (company "0.9.4")
     (request "0.3.0")
     (graphql-mode "20170929.4"))
-    )
-  :keywords '("company" "graphql" "completion" "introspection")
-  )
+  :keywords '("company" "graphql" "completion" "introspection"))


### PR DESCRIPTION
In `company-graphql-pkg.el` has an **excessive** amount of close parentheses that
makes it fails when building the package. And I think because of this is why the package
is no longer exist in MELPA. #1